### PR TITLE
[TASK] Increase metrics collection interval to 10 seconds

### DIFF
--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -135,9 +135,9 @@ def main():
         logger.debug('Starting server at http://localhost:8080...')
         start_http_server(8080)
 
-        # Collect metrics every 3 seconds
+        # Collect metrics every 10 seconds
         while True:
-            time.sleep(3)
+            time.sleep(10)
     except KeyboardInterrupt:
         logger.debug('Received keyboard interrupt, exiting.')
         sys.exit(0)


### PR DESCRIPTION
Collecting metrics every 10 seconds should be enough and additionally reduces the amount of API requests.