### PR TITLE
[BUGFIX] Display correct speed when train is not moving

### DIFF
--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -271,7 +271,7 @@
 				"orientation": "auto",
 				"reduceOptions": {
 					"calcs": [
-						"lastNotNull"
+						"last"
 					],
 					"fields": "",
 					"limit": 1,


### PR DESCRIPTION
This PR fixes the calculation metric for current speed to accept an empty value if the train is not actually moving.