### PR TITLE
[BUGFIX] Handle trips with a delay of 0 minutes (yes, that's possible!)

### DIFF
--- a/metrics_exporter.py
+++ b/metrics_exporter.py
@@ -112,6 +112,8 @@ class DbTrainMetricsCollector():
             # Remove leading plus (+) character from delay information
             if isinstance(delay, str) and delay.startswith('+'):
                 delay = int(delay.lstrip('+'))
+            else:
+                delay = 0
 
             # Return delay data if eva number matches with next station
             if eva_nr == next_station:


### PR DESCRIPTION
One may think that when being on an ICE, there's always a delay of at least 1 minute, because of DB things. However, there might actually be cases where an ICE has a delay of 0 minutes! Therefore, this case is now covered by the metrics exporter as well.