### PR TITLE
[FEATURE] Provide scripts to start, stop and build Docker containers

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -28,3 +28,5 @@ jobs:
         run: ec -verbose
       - name: Lint Python files
         run: pylint *.py
+      - name: Lint shell files
+        run: bash -c 'shopt -s globstar nullglob; shellcheck *.sh'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ and displays information about the current train and next station.
 > DB Onboard APIs.
 
 * [Docker](https://docs.docker.com/get-docker/)
+* [Docker Compose](https://docs.docker.com/compose/install/)
 * Connection to [`WIFIonICE` network](https://int.bahn.de/en/trains/wifi)
 
 ## Usage
@@ -21,11 +22,72 @@ and displays information about the current train and next station.
 > [!TIP]
 > Since bandwidth on trains is limited, it is recommended to pull all
 > necessary Docker images prior to boarding the train. Just clone the
-> repository and run `docker compose build --pull`.
+> repository and run [`build.sh`](#build-docker-images).
+
+### Quickstart
 
 1. Clone the repository
-2. Run `docker compose up -d`
-3. Open Grafana at <http://localhost:9772> in your browser
+2. Run `./start.sh --open --follow`
+
+### Start Docker containers
+
+Use the [`start.sh`](start.sh) script to start Docker containers and
+open the Grafana dashboard in your browser.
+
+```bash
+$ ./start.sh [<flags>]
+```
+
+Flags:
+
+```
+-b, --build     Rebuild local Docker images
+-d, --debug     Display more information when running this script
+-f, --follow    Keep containers running as long as the script runs
+-h, --help      Show this help
+-o, --open      Open the Grafana dashboard in your browser
+-p, --prune     Prune existing Docker volumes to reset persisted data
+-v, --version   Print the current version of this script
+```
+
+_You can also do this manually by running `docker compose up`._
+
+### Stop Docker containers
+
+Use the [`stop.sh`](stop.sh) script to stop running Docker containers.
+
+```bash
+$ ./stop.sh [<flags>]
+```
+
+Flags:
+
+```
+-d, --debug     Display more information when running this command
+-h, --help      Show this help
+-p, --prune     Prune existing Docker volumes to reset persisted data
+-v, --version   Print the current version of this script
+```
+
+_You can also do this manually by running `docker compose down`._
+
+### Build Docker images
+
+Use the [`build.sh`](build.sh) script to (re)build Docker images.
+
+```bash
+$ ./build.sh [<flags>]
+```
+
+Flags:
+
+```
+-d, --debug     Display more information when running this script
+-h, --help      Show this help
+-v, --version   Print the current version of this script
+```
+
+_You can also do this manually by running `docker compose build --pull`._
 
 ## Troubleshooting
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+set -e
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+CYAN="\033[1;36m"
+GRAY="\033[0;90m"
+NC="\033[0m"
+
+debug=0
+
+function _get_version() {
+    local version="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || git rev-parse --short HEAD)"
+
+    echo -e "${RED}db${NC}-train-metrics ${version}"
+    echo -e "${GRAY}by Elias Häußler and contributors${NC}"
+}
+
+function _display_links() {
+    echo -e "${YELLOW}Found an issue?${NC}"
+    echo -e "Report: https://github.com/eliashaeussler/db-train-metrics/issues"
+    echo -e "${YELLOW}Do you like it?${NC}"
+    echo -e "Donate: https://github.com/sponsors/eliashaeussler"
+}
+
+function _usage() {
+    local version="$(_get_version)"
+
+    echo
+    echo -e "$version"
+    echo
+    echo -e "Description:"
+    echo -e "  ${CYAN}Rebuild all relevant Docker images.${NC}"
+    echo
+    echo -e "Usage:"
+    echo -e "  ${CYAN}$0${NC} [<flags>]"
+    echo
+    echo -e "Flags:"
+    echo -e "  ${GREEN}-d, --debug${NC}     Display more information when running this script"
+    echo -e "  ${GREEN}-h, --help${NC}      Show this help"
+    echo -e "  ${GREEN}-v, --version${NC}   Print the current version of this script"
+    echo
+}
+
+function _error() {
+    local message="$1"
+    local exitCode="${2:-1}"
+
+    >&2 echo -e "${RED}${message}${NC}"
+    exit "$exitCode"
+}
+
+function _progress() {
+    local message="$1"
+
+    if [ "$debug" -eq 1 ]; then
+        echo -e "${CYAN}▶ ${message}...${NC}"
+    else
+        printf "%s... " "$message"
+    fi
+}
+
+function _done() {
+    if [ "$debug" -eq 0 ]; then
+        echo -e "${GREEN}Done${NC}"
+    fi
+}
+
+function _failed() {
+    if [ "$debug" -eq 0 ]; then
+        echo -e "${RED}Failed${NC}"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -d|--debug)
+        debug=1
+        shift
+        ;;
+    -h|--help)
+        _usage
+        exit 0
+        ;;
+    -v|--version)
+        echo
+        _get_version
+        echo
+        _display_links
+        echo
+        exit 0
+        ;;
+    -*)
+        _usage
+        _error "Unknown option: $1" 2
+        ;;
+    *)
+        _usage
+        _error "Unknown argument: $1" 2
+        ;;
+    esac
+done
+
+function check_requirements() {
+    _progress "Checking system requirements"
+
+    if ! command -v docker >/dev/null 2>&1; then
+        _failed
+        _error "docker is required, but not installed on your system."
+    fi
+
+    if ! docker compose >/dev/null 2>&1; then
+        _failed
+        _error "docker compose is required, but not installed on your system."
+    fi
+
+    _done
+}
+
+function build_image() {
+    _progress "Building Docker image"
+
+    local command="docker compose build --pull"
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+            _error "An error occurred while building Docker image. Run this script again with --debug flag for more details."
+        fi
+
+        _done
+    fi
+}
+
+function finalize() {
+    echo
+    echo -e "${GREEN}Containers have been successfully built.${NC}"
+    echo -e "Run ${CYAN}./start.sh${NC} to start containers and open the Grafana dashboard."
+}
+
+check_requirements
+build_image
+finalize

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     image: prom/prometheus
     networks:
       - default
+    ports:
+      - "127.0.0.1:9773:9090"
     volumes:
       - './prometheus.yml:/etc/prometheus/prometheus.yml:ro'
       - './data/prometheus:/prometheus'
@@ -19,7 +21,7 @@ services:
     networks:
       - default
     ports:
-      - "9772:3000"
+      - "127.0.0.1:9772:3000"
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+set -e
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+CYAN="\033[1;36m"
+GRAY="\033[0;90m"
+NC="\033[0m"
+
+readonly grafanaUrl="http://localhost:9772"
+readonly prometheusUrl="http://localhost:9773"
+
+build=0
+debug=0
+follow=0
+open=0
+prune=0
+
+function _get_version() {
+    local version="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || git rev-parse --short HEAD)"
+
+    echo -e "${RED}db${NC}-train-metrics ${version}"
+    echo -e "${GRAY}by Elias Häußler and contributors${NC}"
+}
+
+function _display_links() {
+    echo -e "${YELLOW}Found an issue?${NC}"
+    echo -e "Report: https://github.com/eliashaeussler/db-train-metrics/issues"
+    echo -e "${YELLOW}Do you like it?${NC}"
+    echo -e "Donate: https://github.com/sponsors/eliashaeussler"
+}
+
+function _usage() {
+    local version="$(_get_version)"
+
+    echo
+    echo -e "$version"
+    echo
+    echo -e "Description:"
+    echo -e "  ${CYAN}Start Docker containers and open Grafana dashboard.${NC}"
+    echo
+    echo -e "Usage:"
+    echo -e "  ${CYAN}$0${NC} [<flags>]"
+    echo
+    echo -e "Flags:"
+    echo -e "  ${GREEN}-b, --build${NC}     Rebuild local Docker images"
+    echo -e "  ${GREEN}-d, --debug${NC}     Display more information when running this script"
+    echo -e "  ${GREEN}-f, --follow${NC}    Keep containers running as long as the script runs"
+    echo -e "  ${GREEN}-h, --help${NC}      Show this help"
+    echo -e "  ${GREEN}-o, --open${NC}      Open the Grafana dashboard in your browser"
+    echo -e "  ${GREEN}-p, --prune${NC}     Prune existing Docker volumes to reset persisted data"
+    echo -e "  ${GREEN}-v, --version${NC}   Print the current version of this script"
+    echo
+}
+
+function _error() {
+    local message="$1"
+    local exitCode="${2:-1}"
+
+    >&2 echo -e "${RED}${message}${NC}"
+    exit "$exitCode"
+}
+
+function _progress() {
+    local message="$1"
+
+    if [ "$debug" -eq 1 ]; then
+        echo -e "${CYAN}▶ ${message}...${NC}"
+    else
+        printf "%s... " "$message"
+    fi
+}
+
+function _done() {
+    if [ "$debug" -eq 0 ]; then
+        echo -e "${GREEN}Done${NC}"
+    fi
+}
+
+function _failed() {
+    if [ "$debug" -eq 0 ]; then
+        echo -e "${RED}Failed${NC}"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -b|--build)
+        build=1
+        shift
+        ;;
+    -d|--debug)
+        debug=1
+        shift
+        ;;
+    -f|--follow)
+        follow=1
+        shift
+        ;;
+    -h|--help)
+        _usage
+        exit 0
+        ;;
+    -o|--open)
+        open=1
+        shift
+        ;;
+    -p|--prune)
+        prune=1
+        shift
+        ;;
+    -v|--version)
+        echo
+        _get_version
+        echo
+        _display_links
+        echo
+        exit 0
+        ;;
+    -*)
+        _usage
+        _error "Unknown option: $1" 2
+        ;;
+    *)
+        _usage
+        _error "Unknown argument: $1" 2
+        ;;
+    esac
+done
+
+function check_requirements() {
+    _progress "Checking system requirements"
+
+    if ! command -v docker >/dev/null 2>&1; then
+        _failed
+        _error "docker is required, but not installed on your system."
+    fi
+
+    if ! docker compose >/dev/null 2>&1; then
+        _failed
+        _error "docker compose is required, but not installed on your system."
+    fi
+
+    _done
+}
+
+function prune_volumes() {
+    _progress "Pruning Docker volumes"
+
+    local command
+    local commands=("docker compose down --remove-orphans" "rm -rfv data/grafana data/prometheus")
+
+    if [ "$debug" -eq 1 ]; then
+        for command in "${commands[@]}"; do
+            $command
+        done
+    else
+        for command in "${commands[@]}"; do
+            if ! $command >/dev/null 2>&1; then
+                _failed
+                _error "An error occurred while pruning Docker volumes. Run this script again with --debug flag for more details."
+            fi
+        done
+
+        _done
+    fi
+}
+
+function build_image() {
+    _progress "Building Docker image"
+
+    local command="docker compose build"
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+            _error "An error occurred while building Docker image. Run this script again with --debug flag for more details."
+        fi
+
+        _done
+    fi
+}
+
+function start_containers() {
+    _progress "Starting Docker containers"
+
+    local command="docker compose up -d"
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+            _error "Could not start Docker containers. Run this script again with --debug flag for more details."
+        fi
+
+        _done
+    fi
+}
+
+function stop_containers() {
+    _progress "Stopping Docker containers"
+
+    local command="docker compose down --remove-orphans"
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+            _error "Could not stop Docker containers. Run this script again with --debug flag for more details."
+        fi
+
+        _done
+    fi
+}
+
+function open_grafana() {
+    _progress "Opening Grafana in your browser"
+
+    local command
+
+    if command -v xdg-open >/dev/null 2>&1; then
+        command="xdg-open ${grafanaUrl}/?kiosk"
+    else
+        command="open ${grafanaUrl}/?kiosk"
+    fi
+
+    # Make sure Grafana is started
+    sleep 1
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+        else
+            _done
+        fi
+    fi
+}
+
+function show_connection() {
+    printf '\n'
+    printf '+----------------------+------------------------------------------+\n'
+    printf '| %-20s | %-40s |\n' "Service" "URL"
+    printf '+----------------------+------------------------------------------+\n'
+    printf '| %-20s | %-40s |\n' "Grafana" "${grafanaUrl}"
+    printf '| %-20s | %-40s |\n' "Prometheus" "${prometheusUrl}"
+    printf '+----------------------+------------------------------------------+\n'
+    printf '\n'
+}
+
+function cleanup_and_exit() {
+    echo
+    echo -e "${YELLOW}Caught interrupt, shutting down containers.${NC}"
+    stop_containers
+    exit 0
+}
+
+function finalize() {
+    if [ "$follow" -eq 1 ]; then
+        trap cleanup_and_exit INT TERM
+        echo -e "${GRAY}Follow mode enabled. Press Ctrl+C to stop containers and exit.${NC}"
+        tail -f /dev/null
+    else
+        echo -e "${GREEN}All Docker containers are running.${NC}"
+        echo -e "Run ${CYAN}./stop.sh${NC} to stop containers."
+        echo -e "${GRAY}You can also run this script with ${YELLOW}--follow${GRAY} to keep containers open while the script is running.${NC}"
+    fi
+}
+
+check_requirements
+
+if [ "$prune" -eq 1 ]; then
+    prune_volumes
+fi
+
+if [ "$build" -eq 1 ]; then
+    build_image
+fi
+
+start_containers
+
+if [ "$open" -eq 1 ]; then
+    open_grafana
+fi
+
+show_connection
+finalize

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+set -e
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+CYAN="\033[1;36m"
+GRAY="\033[0;90m"
+NC="\033[0m"
+
+debug=0
+prune=0
+
+function _get_version() {
+    local version="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || git rev-parse --short HEAD)"
+
+    echo -e "${RED}db${NC}-train-metrics ${version}"
+    echo -e "${GRAY}by Elias Häußler and contributors${NC}"
+}
+
+function _display_links() {
+    echo -e "${YELLOW}Found an issue?${NC}"
+    echo -e "Report: https://github.com/eliashaeussler/db-train-metrics/issues"
+    echo -e "${YELLOW}Do you like it?${NC}"
+    echo -e "Donate: https://github.com/sponsors/eliashaeussler"
+}
+
+function _usage() {
+    local version="$(_get_version)"
+
+    echo
+    echo -e "$version"
+    echo
+    echo -e "Description:"
+    echo -e "  ${CYAN}Stop currently running Docker containers.${NC}"
+    echo
+    echo -e "Usage:"
+    echo -e "  ${CYAN}$0${NC} [<flags>]"
+    echo
+    echo -e "Flags:"
+    echo -e "  ${GREEN}-d, --debug${NC}     Display more information when running this command"
+    echo -e "  ${GREEN}-h, --help${NC}      Show this help"
+    echo -e "  ${GREEN}-p, --prune${NC}     Prune existing Docker volumes to reset persisted data"
+    echo -e "  ${GREEN}-v, --version${NC}   Print the current version of this script"
+    echo
+}
+
+function _error() {
+    local message="$1"
+    local exitCode="${2:-1}"
+
+    >&2 echo -e "${RED}${message}${NC}"
+    exit "$exitCode"
+}
+
+function _progress() {
+    local message="$1"
+
+    if [ "$debug" -eq 1 ]; then
+        echo -e "${CYAN}▶ ${message}...${NC}"
+    else
+        printf "%s... " "$message"
+    fi
+}
+
+function _done() {
+    if [ "$debug" -eq 0 ]; then
+        echo -e "${GREEN}Done${NC}"
+    fi
+}
+
+function _failed() {
+    if [ "$debug" -eq 0 ]; then
+        echo -e "${RED}Failed${NC}"
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -d|--debug)
+        debug=1
+        shift
+        ;;
+    -h|--help)
+        _usage
+        exit 0
+        ;;
+    -p|--prune)
+        prune=1
+        shift
+        ;;
+    -v|--version)
+        echo
+        _get_version
+        echo
+        _display_links
+        echo
+        exit 0
+        ;;
+    -*)
+        _usage
+        _error "Unknown option: $1" 2
+        ;;
+    *)
+        _usage
+        _error "Unknown argument: $1" 2
+        ;;
+    esac
+done
+
+function stop_containers() {
+    _progress "Stopping Docker containers"
+
+    local command="docker compose down --remove-orphans"
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+            _error "Could not stop Docker containers. Run this script again with --debug flag for more details."
+        fi
+
+        _done
+    fi
+}
+
+function prune_volumes() {
+    _progress "Pruning Docker volumes"
+
+    local command="rm -rfv data/grafana data/prometheus"
+
+    if [ "$debug" -eq 1 ]; then
+        $command
+    else
+        if ! $command >/dev/null 2>&1; then
+            _failed
+            _error "An error occurred while pruning Docker volumes. Run this script again with --debug flag for more details."
+        fi
+
+        _done
+    fi
+}
+
+function finalize() {
+    echo
+    echo -e "${GREEN}Docker containers have been stopped.${NC}"
+    echo -e "Run ${CYAN}./start.sh${NC} to restart them and open the Grafana dashboard."
+}
+
+stop_containers
+
+if [ "$prune" -eq 1 ]; then
+    prune_volumes
+fi
+
+finalize


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI scripts to build, start, stop, and manage the local Docker deployment (build, debug, follow, prune, help and version options); start opens Grafana and shows service URLs.

* **Documentation**
  * README updated with the new script-based workflow, manual docker-compose alternatives, and a Docker Compose documentation link.

* **Chores**
  * Prometheus and Grafana ports now bound to localhost for host-only access.
  * CI: Added shell linting step for .sh files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->