### PR TITLE
[FEATURE] Add `--logs` flag to `start.sh` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Flags:
 -d, --debug     Display more information when running this script
 -f, --follow    Keep containers running as long as the script runs
 -h, --help      Show this help
+-l, --logs      Follow container logs once containers are running
 -o, --open      Open the Grafana dashboard in your browser
 -p, --prune     Prune existing Docker volumes to reset persisted data
 -v, --version   Print the current version of this script

--- a/start.sh
+++ b/start.sh
@@ -15,6 +15,7 @@ readonly prometheusUrl="http://localhost:9773"
 build=0
 debug=0
 follow=0
+logs=0
 open=0
 prune=0
 
@@ -49,6 +50,7 @@ function _usage() {
     echo -e "  ${GREEN}-d, --debug${NC}     Display more information when running this script"
     echo -e "  ${GREEN}-f, --follow${NC}    Keep containers running as long as the script runs"
     echo -e "  ${GREEN}-h, --help${NC}      Show this help"
+    echo -e "  ${GREEN}-l, --logs${NC}      Follow container logs once containers are running"
     echo -e "  ${GREEN}-o, --open${NC}      Open the Grafana dashboard in your browser"
     echo -e "  ${GREEN}-p, --prune${NC}     Prune existing Docker volumes to reset persisted data"
     echo -e "  ${GREEN}-v, --version${NC}   Print the current version of this script"
@@ -102,6 +104,10 @@ while [ $# -gt 0 ]; do
     -h|--help)
         _usage
         exit 0
+        ;;
+    -l|--logs)
+        logs=1
+        shift
         ;;
     -o|--open)
         open=1
@@ -266,11 +272,19 @@ function finalize() {
     if [ "$follow" -eq 1 ]; then
         trap cleanup_and_exit INT TERM
         echo -e "${GRAY}Follow mode enabled. Press Ctrl+C to stop containers and exit.${NC}"
-        tail -f /dev/null
+
+        if [ "$logs" -eq 0 ]; then
+            tail -f /dev/null
+        fi
     else
         echo -e "${GREEN}All Docker containers are running.${NC}"
         echo -e "Run ${CYAN}./stop.sh${NC} to stop containers."
         echo -e "${GRAY}You can also run this script with ${YELLOW}--follow${GRAY} to keep containers open while the script is running.${NC}"
+    fi
+
+    if [ "$logs" -eq 1 ]; then
+        echo
+        docker compose logs -f
     fi
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-l / --logs` command-line flag to display and stream Docker container logs in real-time after startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->