### PR TITLE
[BUGFIX] Extract stopInfo from prepared train dict

### DIFF
--- a/lib/metrics_exporter.py
+++ b/lib/metrics_exporter.py
@@ -157,7 +157,7 @@ class DbTrainMetricsCollector():
             part for part in (trip.get('trainType'), trip.get('vzn'))
             if part is not None
         ).strip() or None
-        stop_info = trip_response.get('stopInfo', {})
+        stop_info = trip.get('stopInfo', {})
         stop_info = stop_info if isinstance(stop_info, dict) else {}
         next_station = stop_info.get('actualNext')
         all_stops = trip.get('stops', [])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trip information extraction to properly access station details and delays, ensuring accurate retrieval of next station and delay data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->